### PR TITLE
Fix voice cache crash with custom --model-path (#13)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ Flask application factory and initialization.
 
 # Keep in sync with pyproject.toml — used as the version fallback when the
 # package isn't installed via pip (e.g. running directly from a clone).
-__version__ = '2.5.3'
+__version__ = '2.5.4'
 
 from flask import Flask
 

--- a/app/services/tts.py
+++ b/app/services/tts.py
@@ -85,10 +85,13 @@ class TTSService:
         audio_path = Path(audio_path)
         tag = active_model_tag((self._active or {}).get('value') or 'english')
         target = self.cache_dir / f'{audio_path.stem}.{tag}.safetensors'
+        # Caching is best-effort: swallow any failure so a broken cache write
+        # never blocks voice loading. safetensors raises SafetensorError (not
+        # OSError) on serialization I/O failures, so we catch broadly.
         try:
             export_model_state(state, target)
             logger.info(f'Saved cloned voice state to {target}')
-        except OSError as e:
+        except Exception as e:
             logger.warning(f'Could not save voice cache to {target}: {e}')
 
     @property

--- a/app/services/tts.py
+++ b/app/services/tts.py
@@ -87,12 +87,13 @@ class TTSService:
         target = self.cache_dir / f'{audio_path.stem}.{tag}.safetensors'
         # Caching is best-effort: swallow any failure so a broken cache write
         # never blocks voice loading. safetensors raises SafetensorError (not
-        # OSError) on serialization I/O failures, so we catch broadly.
+        # OSError) on serialization I/O failures, so we catch broadly. Keep
+        # exc_info=True so unexpected failures stay diagnosable.
         try:
             export_model_state(state, target)
             logger.info(f'Saved cloned voice state to {target}')
-        except Exception as e:
-            logger.warning(f'Could not save voice cache to {target}: {e}')
+        except Exception:
+            logger.warning(f'Could not save voice cache to {target}', exc_info=True)
 
     @property
     def is_loaded(self) -> bool:

--- a/app/services/voice_cache.py
+++ b/app/services/voice_cache.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 from app.config import Config
 
-_ILLEGAL_FS_CHARS = re.compile(r'[\\/:*?"<>|]')
+# Substituted away when sanitizing path-derived tags. Includes filesystem-illegal
+# characters AND `.`, since `parse_safetensors_name` uses `.` to delimit
+# <stem>.<tag>.safetensors — a tag containing a dot would mis-parse.
+_TAG_ILLEGAL_CHARS = re.compile(r'[\\/:*?"<>|.]')
 _CONFIG_EXTENSIONS = ('.yaml', '.yml', '.json')
 
 
@@ -33,7 +36,7 @@ def active_model_tag(raw_model: str) -> str:
             if last.lower().endswith(ext):
                 last = last[: -len(ext)]
                 break
-        canonical = _ILLEGAL_FS_CHARS.sub('_', last)
+        canonical = _TAG_ILLEGAL_CHARS.sub('_', last)
 
     return canonical
 

--- a/app/services/voice_cache.py
+++ b/app/services/voice_cache.py
@@ -3,18 +3,43 @@
 Kept separate from tts.py so it can be exercised without loading pocket-tts.
 """
 
+import re
 from pathlib import Path
 
 from app.config import Config
+
+_ILLEGAL_FS_CHARS = re.compile(r'[\\/:*?"<>|]')
+_CONFIG_EXTENSIONS = ('.yaml', '.yml', '.json')
 
 
 def active_model_tag(raw_model: str) -> str:
     """Normalize a language identifier for use as a filename tag.
 
-    Equivalent names (english, english_2026-01, english_2026-04) map to a
-    single canonical tag so cache files don't duplicate.
+    Handles three input shapes:
+      - plain language identifier (e.g. 'english_2026-04') → unchanged
+      - aliased identifier (e.g. 'english') → canonical alias target
+      - custom --model-path value (e.g. r'C:\\models\\english.yaml') →
+        reduced to the file stem ('english'), since path separators and
+        Windows drive colons are illegal in filenames and would crash
+        safetensors serialization (issue #13).
     """
-    return Config.LEGACY_MODEL_ALIASES.get(raw_model, raw_model)
+    canonical = Config.LEGACY_MODEL_ALIASES.get(raw_model, raw_model)
+
+    # If the value looks like a file path (separators present, or it ends in
+    # a known config extension), reduce it to a filesystem-safe stem.
+    if (
+        '/' in canonical
+        or '\\' in canonical
+        or canonical.lower().endswith(_CONFIG_EXTENSIONS)
+    ):
+        last = canonical.replace('\\', '/').rsplit('/', 1)[-1]
+        for ext in _CONFIG_EXTENSIONS:
+            if last.lower().endswith(ext):
+                last = last[: -len(ext)]
+                break
+        canonical = _ILLEGAL_FS_CHARS.sub('_', last)
+
+    return canonical
 
 
 def known_model_tags() -> set[str]:

--- a/app/services/voice_cache.py
+++ b/app/services/voice_cache.py
@@ -27,11 +27,7 @@ def active_model_tag(raw_model: str) -> str:
 
     # If the value looks like a file path (separators present, or it ends in
     # a known config extension), reduce it to a filesystem-safe stem.
-    if (
-        '/' in canonical
-        or '\\' in canonical
-        or canonical.lower().endswith(_CONFIG_EXTENSIONS)
-    ):
+    if '/' in canonical or '\\' in canonical or canonical.lower().endswith(_CONFIG_EXTENSIONS):
         last = canonical.replace('\\', '/').rsplit('/', 1)[-1]
         for ext in _CONFIG_EXTENSIONS:
             if last.lower().endswith(ext):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ license = {text = "MIT"}
 name = "pocket-tts-openai-server"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.5.3"
+version = "2.5.4"
 
 dependencies = [
   "flask>=3.0.0",

--- a/tests/test_tts_service.py
+++ b/tests/test_tts_service.py
@@ -355,6 +355,40 @@ def test_get_voice_state_tolerates_safetensor_serialize_error(
 
 
 @patch('app.services.tts._ensure_pocket_tts')
+def test_save_cloned_state_failure_logs_traceback(
+    _ensure, tmp_path, monkeypatch, mock_tts_model, caplog
+):
+    """Cache write failures must include the traceback in logs (via exc_info)
+    so the underlying cause stays diagnosable even though the warning is swallowed."""
+    import logging
+
+    from safetensors import SafetensorError
+
+    voices = tmp_path / 'voices'
+    voices.mkdir()
+    cache = tmp_path / 'voice_cache'
+    (voices / 'emma.wav').write_bytes(b'fake-audio')
+    monkeypatch.setattr('app.config.Config.VOICE_CACHE_DIR', str(cache))
+
+    service = TTSService()
+    service.set_voices_dir(str(voices))
+    mock_tts_model.get_state_for_audio_prompt.return_value = {'fake': 'state'}
+    with patch('app.services.tts.TTSModel') as MockModel:
+        MockModel.load_model.return_value = mock_tts_model
+        service.load_model(language='english', quantize=False)
+
+    with patch('app.services.tts.export_model_state') as mock_export:
+        mock_export.side_effect = SafetensorError('I/O error: simulated failure')
+        with caplog.at_level(logging.WARNING, logger='PocketTTS.tts'):
+            service.get_voice_state('emma')
+
+    cache_warnings = [r for r in caplog.records if 'Could not save voice cache' in r.message]
+    assert cache_warnings, 'expected a warning about the failed cache save'
+    # exc_info must be set so the traceback is captured.
+    assert cache_warnings[0].exc_info is not None
+
+
+@patch('app.services.tts._ensure_pocket_tts')
 def test_get_voice_state_regenerates_when_source_newer(
     _ensure, tmp_path, monkeypatch, mock_tts_model
 ):

--- a/tests/test_tts_service.py
+++ b/tests/test_tts_service.py
@@ -284,6 +284,77 @@ def test_get_voice_state_saves_clone_to_cache(_ensure, tmp_path, monkeypatch, mo
 
 
 @patch('app.services.tts._ensure_pocket_tts')
+def test_get_voice_state_saves_clone_under_custom_model_path(
+    _ensure, tmp_path, monkeypatch, mock_tts_model
+):
+    """Issue #13: when started with --model-path "<full file path>", the cache
+    filename must not include the raw path. Otherwise safetensors raises a
+    serialization I/O error on Windows because `:` and `\\` are illegal in
+    filenames. The cache filename must be safe and the call must succeed."""
+    voices = tmp_path / 'voices'
+    voices.mkdir()
+    cache = tmp_path / 'voice_cache'
+    (voices / 'Aadi.wav').write_bytes(b'fake-audio')
+    monkeypatch.setattr('app.config.Config.VOICE_CACHE_DIR', str(cache))
+
+    service = TTSService()
+    service.set_voices_dir(str(voices))
+    mock_tts_model.get_state_for_audio_prompt.return_value = {'fake': 'state'}
+    with patch('app.services.tts.TTSModel') as MockModel:
+        MockModel.load_model.return_value = mock_tts_model
+        # Simulate the user starting the server with --model-path on Windows.
+        service.load_model(
+            model_path=r'C:\PocketTTS-Server\model\languages\english\english.yaml',
+            quantize=False,
+        )
+
+    with patch('app.services.tts.export_model_state') as mock_export:
+        state = service.get_voice_state('Aadi')
+
+    assert state == {'fake': 'state'}
+    mock_export.assert_called_once()
+    target_path = mock_export.call_args.args[1]
+    name = target_path.name if hasattr(target_path, 'name') else str(target_path).rsplit('/', 1)[-1]
+    # The filename must contain no characters disallowed in Windows filenames.
+    assert not any(c in name for c in r'\/:*?"<>|'), (
+        f'cache filename {name!r} contains path-illegal chars'
+    )
+    # Stem prefix preserved; suffix is .safetensors.
+    assert name.startswith('Aadi.')
+    assert name.endswith('.safetensors')
+
+
+@patch('app.services.tts._ensure_pocket_tts')
+def test_get_voice_state_tolerates_safetensor_serialize_error(
+    _ensure, tmp_path, monkeypatch, mock_tts_model
+):
+    """Issue #13: SafetensorError does not inherit from OSError, so a serialize
+    failure used to bubble up and break voice loading entirely. Cache writes
+    are best-effort: any failure must be logged and the voice must still load."""
+    from safetensors import SafetensorError
+
+    voices = tmp_path / 'voices'
+    voices.mkdir()
+    cache = tmp_path / 'voice_cache'
+    (voices / 'emma.wav').write_bytes(b'fake-audio')
+    monkeypatch.setattr('app.config.Config.VOICE_CACHE_DIR', str(cache))
+
+    service = TTSService()
+    service.set_voices_dir(str(voices))
+    mock_tts_model.get_state_for_audio_prompt.return_value = {'fake': 'state'}
+    with patch('app.services.tts.TTSModel') as MockModel:
+        MockModel.load_model.return_value = mock_tts_model
+        service.load_model(language='english', quantize=False)
+
+    with patch('app.services.tts.export_model_state') as mock_export:
+        mock_export.side_effect = SafetensorError('I/O error: simulated failure')
+        # Must NOT raise — caching is best-effort.
+        state = service.get_voice_state('emma')
+
+    assert state == {'fake': 'state'}
+
+
+@patch('app.services.tts._ensure_pocket_tts')
 def test_get_voice_state_regenerates_when_source_newer(
     _ensure, tmp_path, monkeypatch, mock_tts_model
 ):

--- a/tests/test_voice_cache.py
+++ b/tests/test_voice_cache.py
@@ -48,6 +48,21 @@ def test_active_model_tag_idempotent_for_plain_language():
     assert active_model_tag('french_24l') == 'french_24l'
 
 
+def test_active_model_tag_strips_dots_from_derived_tag():
+    """A model path like 'english.v2.yaml' must NOT yield a tag with internal
+    dots — `parse_safetensors_name` uses `.` to split <stem>.<tag>.safetensors,
+    so a dotted tag would be mis-parsed and break voice listing."""
+    tag = active_model_tag('/opt/models/english.v2.yaml')
+    assert '.' not in tag
+
+
+def test_active_model_tag_handles_bundled_hash_filename():
+    """The bundled model is named like 'b6369a24.yaml' — the derived tag
+    should be the hex stem, no dots."""
+    tag = active_model_tag('/app/model/b6369a24.yaml')
+    assert tag == 'b6369a24'
+
+
 def test_known_model_tags_includes_all_supported_plus_alias_targets():
     tags = known_model_tags()
     assert 'english_2026-04' in tags

--- a/tests/test_voice_cache.py
+++ b/tests/test_voice_cache.py
@@ -22,6 +22,32 @@ def test_active_model_tag_canonicalizes_english_2026_01():
     assert active_model_tag('english_2026-01') == 'english_2026-04'
 
 
+def test_active_model_tag_handles_windows_path():
+    """A custom --model-path value (full Windows file path) must produce a
+    filename-safe tag — not a literal path with `:` and `\\` that breaks
+    safetensors serialization on Windows (issue #13)."""
+    tag = active_model_tag(r'C:\PocketTTS-Server\model\languages\english\english.yaml')
+    # Tag must contain no characters disallowed in Windows filenames.
+    assert not any(c in tag for c in r'\/:*?"<>|')
+    # Stem-derived: english.yaml -> english is the natural choice.
+    assert tag == 'english'
+
+
+def test_active_model_tag_handles_posix_path():
+    """A POSIX absolute path to a custom model yaml should also produce a
+    filename-safe tag derived from the file stem."""
+    tag = active_model_tag('/opt/pocket-tts/models/german_24l.yaml')
+    assert '/' not in tag
+    assert tag == 'german_24l'
+
+
+def test_active_model_tag_idempotent_for_plain_language():
+    """Plain language identifiers must be unaffected by sanitization so the
+    existing tag/cache lookup logic continues to work for built-in models."""
+    assert active_model_tag('german_24l') == 'german_24l'
+    assert active_model_tag('french_24l') == 'french_24l'
+
+
 def test_known_model_tags_includes_all_supported_plus_alias_targets():
     tags = known_model_tags()
     assert 'english_2026-04' in tags


### PR DESCRIPTION
## Summary
- Fixes #13: when the server is started with `--model-path "<full file path>"`, voice cloning crashes with `Error while serializing: I/O error: ... (os error 123)` on Windows.
- Root cause: `_active['value']` holds the raw model path, which `active_model_tag` returned verbatim. The cache target became e.g. `voice_cache/Aadi.C:\PocketTTS-Server\...\english.yaml.safetensors` — invalid on Windows because `:` and `\` are illegal in filenames. `safetensors` then raises `SafetensorError`, which (unlike `OSError`) was not caught by `_save_cloned_state`, so it propagated and broke voice loading entirely.
- Fix in two parts (defense in depth):
  1. `active_model_tag` now reduces path-like model identifiers to a filesystem-safe stem (`C:\...\english.yaml` → `english`).
  2. Broadened the cache-write handler in `_save_cloned_state` from `except OSError` to `except Exception` so any future serialization failure stays best-effort and never blocks voice loading.
