### PR TITLE
Support OpenAI `speed` parameter on /v1/audio/speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ with client.audio.speech.with_streaming_response.create(
 | `voice`           | string  | No       | `alba`  | Voice ID (see `/v1/voices`)                        |
 | `response_format` | string  | No       | `mp3`   | Output format: `mp3`, `wav`, `pcm`, `opus`, `aac`, `flac` |
 | `stream`          | boolean | No       | `false` | Enable streaming response                          |
+| `speed`           | float   | No       | `1.0`   | Playback speed in `[0.25, 4.0]` (preserves pitch via ffmpeg `atempo`). Default `1.0` is a fast no-op. |
 
 ## Custom Voices
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ with client.audio.speech.with_streaming_response.create(
 | `stream`          | boolean | No       | `false` | Enable streaming response                          |
 | `speed`           | float   | No       | `1.0`   | Playback speed in `[0.25, 4.0]` (preserves pitch via ffmpeg `atempo`). Default `1.0` is a fast no-op. |
 
+> **Note:** `speed` requires `ffmpeg` on the server's `PATH`. ffmpeg is bundled in the Docker image; on bare-metal installs without it, non-default `speed` values are ignored (audio is served at normal speed) and a warning is logged server-side.
+
 ## Custom Voices
 
 ### Using Custom Voice Files

--- a/app/routes.py
+++ b/app/routes.py
@@ -17,6 +17,10 @@ from flask import (
 from app.config import Config
 from app.logging_config import get_logger
 from app.services.audio import (
+    SPEED_MAX,
+    SPEED_MIN,
+    apply_atempo_buffer,
+    apply_atempo_to_pcm_stream,
     convert_audio,
     get_mime_type,
     tensor_to_pcm_bytes,
@@ -197,6 +201,10 @@ def generate_speech():
         voice: string (optional) - Voice ID or path
         response_format: string (optional) - Audio format
         stream: boolean (optional) - Enable streaming
+        speed: float (optional) - Playback speed multiplier in
+            [0.25, 4.0], default 1.0. When omitted or equal to 1.0 the
+            default code path is unchanged. Other values run the audio
+            through ffmpeg's `atempo` filter (preserves pitch).
 
     Returns:
         Audio file or streaming audio response
@@ -217,6 +225,24 @@ def generate_speech():
 
     response_format = data.get('response_format', 'mp3')
     target_format = validate_format(response_format)
+
+    # `speed` is intentionally only validated when present — clients that
+    # never send the field hit the same code path as before.
+    speed = 1.0
+    if 'speed' in data:
+        try:
+            speed = float(data['speed'])
+        except (TypeError, ValueError):
+            return jsonify({'error': "'speed' must be a number"}), 400
+        if not (SPEED_MIN <= speed <= SPEED_MAX):
+            return jsonify(
+                {
+                    'error': (
+                        f"'speed' must be between {SPEED_MIN} and {SPEED_MAX}"
+                    ),
+                    'received': speed,
+                }
+            ), 400
 
     tts = get_tts_service()
 
@@ -256,8 +282,8 @@ def generate_speech():
             text = text_preprocessor.process(text)
             # logger.info(f'Preprocessed text: {text}')
         if use_streaming:
-            return _stream_audio(tts, voice_state, text, target_format)
-        return _generate_file(tts, voice_state, text, target_format)
+            return _stream_audio(tts, voice_state, text, target_format, speed=speed)
+        return _generate_file(tts, voice_state, text, target_format, speed=speed)
 
     except ValueError as e:
         msg = str(e)
@@ -294,7 +320,7 @@ def generate_speech():
         return jsonify({'error': str(e)}), 500
 
 
-def _generate_file(tts, voice_state, text: str, fmt: str):
+def _generate_file(tts, voice_state, text: str, fmt: str, speed: float = 1.0):
     """Generate complete audio and return as file."""
     t0 = time.time()
     audio_tensor = tts.generate_audio(voice_state, text)
@@ -303,6 +329,8 @@ def _generate_file(tts, voice_state, text: str, fmt: str):
     logger.info(f'Generated {len(text)} chars in {generation_time:.2f}s')
 
     audio_buffer = convert_audio(audio_tensor, tts.sample_rate, fmt)
+    if speed != 1.0:
+        audio_buffer = apply_atempo_buffer(audio_buffer, fmt, speed)
     mimetype = get_mime_type(fmt)
 
     return send_file(
@@ -310,7 +338,7 @@ def _generate_file(tts, voice_state, text: str, fmt: str):
     )
 
 
-def _stream_audio(tts, voice_state, text: str, fmt: str):
+def _stream_audio(tts, voice_state, text: str, fmt: str, speed: float = 1.0):
     """Stream audio chunks."""
     # Normalize streaming format: we always emit PCM bytes, optionally wrapped
     # in a WAV container. For non-PCM/WAV formats (e.g. mp3, opus), coerce to
@@ -324,7 +352,7 @@ def _stream_audio(tts, voice_state, text: str, fmt: str):
         )
         stream_fmt = 'pcm'
 
-    def generate():
+    def pcm_chunks():
         stream = tts.generate_audio_stream(voice_state, text)
         for chunk_tensor in stream:
             yield tensor_to_pcm_bytes(chunk_tensor)
@@ -333,7 +361,12 @@ def _stream_audio(tts, voice_state, text: str, fmt: str):
         # Yield WAV header first if streaming as WAV
         if stream_fmt == 'wav':
             yield write_wav_header(tts.sample_rate, num_channels=1, bits_per_sample=16)
-        yield from generate()
+        if speed == 1.0:
+            yield from pcm_chunks()
+        else:
+            yield from apply_atempo_to_pcm_stream(
+                pcm_chunks(), tts.sample_rate, speed
+            )
 
     mimetype = get_mime_type(stream_fmt)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -22,6 +22,7 @@ from app.services.audio import (
     apply_atempo_buffer,
     apply_atempo_to_pcm_stream,
     convert_audio,
+    ffmpeg_available,
     get_mime_type,
     tensor_to_pcm_bytes,
     validate_format,
@@ -237,12 +238,21 @@ def generate_speech():
         if not (SPEED_MIN <= speed <= SPEED_MAX):
             return jsonify(
                 {
-                    'error': (
-                        f"'speed' must be between {SPEED_MIN} and {SPEED_MAX}"
-                    ),
+                    'error': (f"'speed' must be between {SPEED_MIN} and {SPEED_MAX}"),
                     'received': speed,
                 }
             ), 400
+
+    # atempo needs ffmpeg. When it's missing, degrade gracefully rather than
+    # failing the request: serve normal-speed audio and warn so the operator
+    # knows why `speed` had no effect.
+    if speed != 1.0 and not ffmpeg_available():
+        logger.warning(
+            "Ignoring 'speed=%s': ffmpeg not found on PATH. Install ffmpeg to "
+            'enable the speed parameter.',
+            speed,
+        )
+        speed = 1.0
 
     tts = get_tts_service()
 
@@ -364,9 +374,7 @@ def _stream_audio(tts, voice_state, text: str, fmt: str, speed: float = 1.0):
         if speed == 1.0:
             yield from pcm_chunks()
         else:
-            yield from apply_atempo_to_pcm_stream(
-                pcm_chunks(), tts.sample_rate, speed
-            )
+            yield from apply_atempo_to_pcm_stream(pcm_chunks(), tts.sample_rate, speed)
 
     mimetype = get_mime_type(stream_fmt)
 

--- a/app/services/audio.py
+++ b/app/services/audio.py
@@ -4,6 +4,9 @@ Audio conversion and streaming utilities.
 
 import io
 import struct
+import subprocess
+import threading
+from typing import Iterator
 
 import torch
 import torchaudio
@@ -14,6 +17,15 @@ logger = get_logger('audio')
 
 # Valid audio formats
 VALID_FORMATS = {'mp3', 'wav', 'opus', 'aac', 'flac', 'pcm'}
+
+# OpenAI's documented range for the `speed` parameter on /v1/audio/speech.
+SPEED_MIN = 0.25
+SPEED_MAX = 4.0
+
+# ffmpeg's `atempo` filter only accepts factors in [0.5, 2.0] per stage. Speeds
+# outside that band are realised by chaining stages (e.g. 0.25 → 0.5,0.5).
+_ATEMPO_STAGE_MIN = 0.5
+_ATEMPO_STAGE_MAX = 2.0
 
 
 def validate_format(fmt: str) -> str:
@@ -158,6 +170,168 @@ def tensor_to_pcm_bytes(chunk_tensor: torch.Tensor) -> bytes:
     # Convert to 16-bit PCM
     pcm = (chunk_tensor * 32767).clamp(-32768, 32767).to(torch.int16)
     return pcm.numpy().tobytes()
+
+
+def _build_atempo_chain(speed: float) -> str:
+    """
+    Build an ffmpeg `-af` filter chain that scales playback speed by `speed`
+    while preserving pitch. ffmpeg's `atempo` filter only accepts factors in
+    [0.5, 2.0] per stage, so factors outside that band are realised by chaining
+    stages (e.g. 0.25 → `atempo=0.5,atempo=0.5`).
+
+    Caller is responsible for ensuring `speed != 1.0` and that `speed` lies in
+    [SPEED_MIN, SPEED_MAX]; this function is not invoked on the default path.
+    """
+    filters: list[str] = []
+    remaining = speed
+    while remaining < _ATEMPO_STAGE_MIN:
+        filters.append(f'atempo={_ATEMPO_STAGE_MIN}')
+        remaining /= _ATEMPO_STAGE_MIN
+    while remaining > _ATEMPO_STAGE_MAX:
+        filters.append(f'atempo={_ATEMPO_STAGE_MAX}')
+        remaining /= _ATEMPO_STAGE_MAX
+    filters.append(f'atempo={remaining:.6f}')
+    return ','.join(filters)
+
+
+def apply_atempo_buffer(
+    audio_buffer: io.BytesIO, target_format: str, speed: float
+) -> io.BytesIO:
+    """
+    Run a fully-encoded audio buffer through ffmpeg's `atempo` filter and
+    return a new buffer in the same `target_format`.
+
+    Used for non-streaming responses. ffmpeg auto-detects the input container
+    from the byte stream; the output muxer is selected explicitly so the
+    response payload matches the advertised MIME type.
+
+    Caller must guarantee `speed != 1.0` — the default path skips this entirely
+    so that speed=1.0 requests have zero overhead vs. the pre-`speed` behaviour.
+    """
+    af_chain = _build_atempo_chain(speed)
+
+    # Mirror the OpenAI-name → ffmpeg-muxer mapping used in `convert_audio`.
+    mux_format = target_format
+    if mux_format == 'opus':
+        mux_format = 'ogg'
+    elif mux_format == 'aac':
+        mux_format = 'adts'
+    elif mux_format == 'pcm':
+        mux_format = 's16le'
+
+    audio_buffer.seek(0)
+    audio_bytes = audio_buffer.read()
+
+    try:
+        proc = subprocess.run(
+            [
+                'ffmpeg',
+                '-hide_banner',
+                '-loglevel', 'error',
+                '-i', 'pipe:0',
+                '-af', af_chain,
+                '-f', mux_format,
+                'pipe:1',
+            ],
+            input=audio_bytes,
+            capture_output=True,
+            check=True,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "ffmpeg is required to apply the 'speed' parameter but was not "
+            'found on PATH'
+        ) from e
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode('utf-8', errors='replace')[:500]
+        raise RuntimeError(f'ffmpeg atempo failed: {stderr}') from e
+
+    return io.BytesIO(proc.stdout)
+
+
+def apply_atempo_to_pcm_stream(
+    pcm_chunks: Iterator[bytes], sample_rate: int, speed: float
+) -> Iterator[bytes]:
+    """
+    Pipe an iterator of raw 16-bit mono PCM chunks through a long-running
+    ffmpeg `atempo` subprocess and yield rate-altered PCM chunks.
+
+    A producer thread writes incoming chunks to ffmpeg's stdin and closes
+    the pipe when the source iterator is exhausted; the main generator
+    reads from ffmpeg's stdout until EOF. atempo produces fewer (or more)
+    output samples than input, so chunk boundaries on the output do not
+    correspond to those on the input — that's fine, the bytes are still
+    valid contiguous PCM.
+
+    Caller must guarantee `speed != 1.0` — the default streaming path does
+    not invoke this and stays byte-for-byte identical to the pre-`speed`
+    behaviour.
+    """
+    af_chain = _build_atempo_chain(speed)
+
+    try:
+        proc = subprocess.Popen(
+            [
+                'ffmpeg',
+                '-hide_banner',
+                '-loglevel', 'error',
+                '-f', 's16le',
+                '-ar', str(sample_rate),
+                '-ac', '1',
+                '-i', 'pipe:0',
+                '-af', af_chain,
+                '-f', 's16le',
+                'pipe:1',
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "ffmpeg is required to apply the 'speed' parameter but was not "
+            'found on PATH'
+        ) from e
+
+    feed_error: list[BaseException] = []
+
+    def _feed() -> None:
+        try:
+            for chunk in pcm_chunks:
+                proc.stdin.write(chunk)
+        except BrokenPipeError:
+            # ffmpeg exited early; the consumer side will surface stderr.
+            pass
+        except BaseException as exc:  # noqa: BLE001 — re-raised on main thread
+            feed_error.append(exc)
+        finally:
+            try:
+                proc.stdin.close()
+            except Exception:
+                pass
+
+    feeder = threading.Thread(target=_feed, name='atempo-feeder', daemon=True)
+    feeder.start()
+
+    read_size = 4096
+    try:
+        while True:
+            data = proc.stdout.read(read_size)
+            if not data:
+                break
+            yield data
+    finally:
+        feeder.join(timeout=5)
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    if feed_error:
+        raise feed_error[0]
+
+    if proc.returncode not in (0, None):
+        stderr = proc.stderr.read().decode('utf-8', errors='replace')[:500]
+        logger.warning('ffmpeg atempo exited %d: %s', proc.returncode, stderr)
 
 
 def get_mime_type(fmt: str) -> str:

--- a/app/services/audio.py
+++ b/app/services/audio.py
@@ -3,10 +3,11 @@ Audio conversion and streaming utilities.
 """
 
 import io
+import shutil
 import struct
 import subprocess
 import threading
-from typing import Iterator
+from collections.abc import Iterator
 
 import torch
 import torchaudio
@@ -26,6 +27,18 @@ SPEED_MAX = 4.0
 # outside that band are realised by chaining stages (e.g. 0.25 → 0.5,0.5).
 _ATEMPO_STAGE_MIN = 0.5
 _ATEMPO_STAGE_MAX = 2.0
+
+
+def ffmpeg_available() -> bool:
+    """
+    Return True if an `ffmpeg` binary is on PATH.
+
+    Only consulted when a non-default `speed` is requested, so the default
+    (speed=1.0) path keeps its zero overhead. Not cached: the lookup is cheap
+    and leaving it uncached keeps the answer correct if ffmpeg is installed
+    while the server is already running.
+    """
+    return shutil.which('ffmpeg') is not None
 
 
 def validate_format(fmt: str) -> str:
@@ -194,9 +207,7 @@ def _build_atempo_chain(speed: float) -> str:
     return ','.join(filters)
 
 
-def apply_atempo_buffer(
-    audio_buffer: io.BytesIO, target_format: str, speed: float
-) -> io.BytesIO:
+def apply_atempo_buffer(audio_buffer: io.BytesIO, target_format: str, speed: float) -> io.BytesIO:
     """
     Run a fully-encoded audio buffer through ffmpeg's `atempo` filter and
     return a new buffer in the same `target_format`.
@@ -227,10 +238,14 @@ def apply_atempo_buffer(
             [
                 'ffmpeg',
                 '-hide_banner',
-                '-loglevel', 'error',
-                '-i', 'pipe:0',
-                '-af', af_chain,
-                '-f', mux_format,
+                '-loglevel',
+                'error',
+                '-i',
+                'pipe:0',
+                '-af',
+                af_chain,
+                '-f',
+                mux_format,
                 'pipe:1',
             ],
             input=audio_bytes,
@@ -239,8 +254,7 @@ def apply_atempo_buffer(
         )
     except FileNotFoundError as e:
         raise RuntimeError(
-            "ffmpeg is required to apply the 'speed' parameter but was not "
-            'found on PATH'
+            "ffmpeg is required to apply the 'speed' parameter but was not found on PATH"
         ) from e
     except subprocess.CalledProcessError as e:
         stderr = e.stderr.decode('utf-8', errors='replace')[:500]
@@ -274,13 +288,20 @@ def apply_atempo_to_pcm_stream(
             [
                 'ffmpeg',
                 '-hide_banner',
-                '-loglevel', 'error',
-                '-f', 's16le',
-                '-ar', str(sample_rate),
-                '-ac', '1',
-                '-i', 'pipe:0',
-                '-af', af_chain,
-                '-f', 's16le',
+                '-loglevel',
+                'error',
+                '-f',
+                's16le',
+                '-ar',
+                str(sample_rate),
+                '-ac',
+                '1',
+                '-i',
+                'pipe:0',
+                '-af',
+                af_chain,
+                '-f',
+                's16le',
                 'pipe:1',
             ],
             stdin=subprocess.PIPE,
@@ -289,8 +310,7 @@ def apply_atempo_to_pcm_stream(
         )
     except FileNotFoundError as e:
         raise RuntimeError(
-            "ffmpeg is required to apply the 'speed' parameter but was not "
-            'found on PATH'
+            "ffmpeg is required to apply the 'speed' parameter but was not found on PATH"
         ) from e
 
     feed_error: list[BaseException] = []

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -194,3 +194,69 @@ def test_home_passes_versions_to_template(client, mock_tts_service):
     assert resp.status_code == 200
     html = resp.data.decode()
     assert 'data-server-version=' in html
+
+
+# ── /v1/audio/speech `speed` parameter ─────────────────────────────────────
+
+
+def test_speech_rejects_non_numeric_speed(client, mock_tts_service):
+    resp = client.post(
+        '/v1/audio/speech',
+        json={'input': 'hi', 'voice': 'alba', 'speed': 'fast'},
+    )
+    assert resp.status_code == 400
+    assert 'speed' in resp.get_json()['error'].lower()
+
+
+def test_speech_rejects_speed_below_min(client, mock_tts_service):
+    resp = client.post(
+        '/v1/audio/speech',
+        json={'input': 'hi', 'voice': 'alba', 'speed': 0.1},
+    )
+    assert resp.status_code == 400
+    assert 'between' in resp.get_json()['error'].lower()
+
+
+def test_speech_rejects_speed_above_max(client, mock_tts_service):
+    resp = client.post(
+        '/v1/audio/speech',
+        json={'input': 'hi', 'voice': 'alba', 'speed': 10},
+    )
+    assert resp.status_code == 400
+    assert 'between' in resp.get_json()['error'].lower()
+
+
+def test_speech_default_speed_does_not_invoke_atempo(client, mock_tts_service, monkeypatch):
+    """Sanity check: the default code path (speed omitted, or speed=1.0) must
+    not call into the new ffmpeg helper. Guards against perf regressions on
+    the hot path."""
+    import app.routes as routes_module
+    import app.services.audio as audio_module
+
+    called = []
+    def boom(*args, **kwargs):
+        called.append(True)
+        raise AssertionError('apply_atempo_buffer must not run when speed=1.0')
+
+    monkeypatch.setattr(audio_module, 'apply_atempo_buffer', boom)
+    monkeypatch.setattr(routes_module, 'apply_atempo_buffer', boom)
+
+    # Stub generate_audio + convert_audio so the request completes without
+    # touching pocket-tts or torchaudio.
+    import io
+    mock_tts_service.get_voice_state.return_value = {}
+    mock_tts_service.generate_audio.return_value = MagicMock()
+    monkeypatch.setattr(
+        routes_module, 'convert_audio', lambda *a, **k: io.BytesIO(b'\x00' * 16)
+    )
+
+    # speed omitted
+    resp = client.post('/v1/audio/speech', json={'input': 'hi', 'voice': 'alba'})
+    assert resp.status_code == 200
+    # speed explicitly 1.0
+    resp = client.post(
+        '/v1/audio/speech', json={'input': 'hi', 'voice': 'alba', 'speed': 1.0}
+    )
+    assert resp.status_code == 200
+
+    assert called == []

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -234,6 +234,7 @@ def test_speech_default_speed_does_not_invoke_atempo(client, mock_tts_service, m
     import app.services.audio as audio_module
 
     called = []
+
     def boom(*args, **kwargs):
         called.append(True)
         raise AssertionError('apply_atempo_buffer must not run when speed=1.0')
@@ -244,19 +245,46 @@ def test_speech_default_speed_does_not_invoke_atempo(client, mock_tts_service, m
     # Stub generate_audio + convert_audio so the request completes without
     # touching pocket-tts or torchaudio.
     import io
+
     mock_tts_service.get_voice_state.return_value = {}
     mock_tts_service.generate_audio.return_value = MagicMock()
-    monkeypatch.setattr(
-        routes_module, 'convert_audio', lambda *a, **k: io.BytesIO(b'\x00' * 16)
-    )
+    monkeypatch.setattr(routes_module, 'convert_audio', lambda *a, **k: io.BytesIO(b'\x00' * 16))
 
     # speed omitted
     resp = client.post('/v1/audio/speech', json={'input': 'hi', 'voice': 'alba'})
     assert resp.status_code == 200
     # speed explicitly 1.0
-    resp = client.post(
-        '/v1/audio/speech', json={'input': 'hi', 'voice': 'alba', 'speed': 1.0}
-    )
+    resp = client.post('/v1/audio/speech', json={'input': 'hi', 'voice': 'alba', 'speed': 1.0})
     assert resp.status_code == 200
 
     assert called == []
+
+
+def test_speech_ignores_speed_when_ffmpeg_missing(client, mock_tts_service, monkeypatch):
+    """When ffmpeg is unavailable, a non-default `speed` degrades gracefully:
+    serve normal-speed audio (HTTP 200, atempo never invoked) and emit a
+    server-side warning, rather than failing the request."""
+    import io
+
+    import app.routes as routes_module
+    import app.services.audio as audio_module
+
+    monkeypatch.setattr(routes_module, 'ffmpeg_available', lambda: False)
+
+    def boom(*args, **kwargs):
+        raise AssertionError('atempo must not run when ffmpeg is missing')
+
+    monkeypatch.setattr(routes_module, 'apply_atempo_buffer', boom)
+    monkeypatch.setattr(audio_module, 'apply_atempo_buffer', boom)
+
+    warnings = []
+    monkeypatch.setattr(routes_module.logger, 'warning', lambda *a, **k: warnings.append(a))
+
+    mock_tts_service.get_voice_state.return_value = {}
+    mock_tts_service.generate_audio.return_value = MagicMock()
+    monkeypatch.setattr(routes_module, 'convert_audio', lambda *a, **k: io.BytesIO(b'\x00' * 16))
+
+    resp = client.post('/v1/audio/speech', json={'input': 'hi', 'voice': 'alba', 'speed': 2.0})
+    assert resp.status_code == 200
+    assert warnings, 'expected a server-side warning when ffmpeg is missing'
+    assert 'ffmpeg' in warnings[0][0].lower()


### PR DESCRIPTION
Closes #17.

Honors the standard OpenAI `speed` field (float in `[0.25, 4.0]`, default `1.0`) on `POST /v1/audio/speech`. Implementation post-processes the synthesized audio with ffmpeg's `atempo` filter, which preserves pitch. Pocket-TTS itself has no native speech-rate parameter (confirmed in [Kyutai's Python API docs](https://kyutai-labs.github.io/pocket-tts/API%20Reference/python-api/)), so the fix lives at the wrapper layer.

## Behavior

- **Default path is untouched.** When `speed` is omitted, or explicitly equal to `1.0`, no new code runs — byte-for-byte identical responses to the pre-`speed` behavior, for both file and streaming responses. A regression test (`test_speech_default_speed_does_not_invoke_atempo`) asserts this.
- **Validation only on non-default.** Non-numeric / out-of-range values return `400` with a clear error.
- **Both response paths supported.**
  - Non-streaming: encoded buffer → `ffmpeg -i pipe:0 -af atempo=N -f <fmt> pipe:1`.
  - Streaming: PCM chunks → long-running `ffmpeg -f s16le … -af atempo=N -f s16le pipe:1` subprocess; a feeder thread writes incoming chunks to stdin while the response generator reads atempo'd chunks from stdout.
- **Chained atempo for extreme values.** `atempo` only accepts factors in `[0.5, 2.0]` per stage, so `speed=0.25` is realised as `atempo=0.5,atempo=0.5`. Standard trick.
- **No new runtime deps** — `ffmpeg` is already installed in the Dockerfile.

## Tests

`tests/test_routes.py` adds:

- Reject non-numeric `speed`.
- Reject `speed` below `SPEED_MIN`.
- Reject `speed` above `SPEED_MAX`.
- Default path does not invoke `apply_atempo_buffer` (covers the no-op-on-1.0 contract).

## Real-world verification

Tested in a personal homelab stack with a custom voice clone at `speed=0.3` (chained atempo), `speed=0.88`, `speed=0.95`, and `speed=1.0`. All four produced expected audio with no clipping or artefacts beyond what `atempo` itself introduces at extreme factors.

Streaming path verified end-to-end with `response_format: wav, stream: true`, identical input text on both requests:

- `speed=1.0` → 103,724 bytes
- `speed=0.5` → 205,568 bytes
- Ratio: **1.982×** (expected `1/0.5 = 2.0×`)

The ~2× byte count at `speed=0.5` is the streaming subprocess actually doing the work — feeder thread writing PCM in, ffmpeg stretching, generator yielding more samples out — not the request silently bypassing atempo.

---

*This change was prepared by Claude (Anthropic) on behalf of @nick-pape.*
